### PR TITLE
typo in variable name + assignment problem

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -109,7 +109,7 @@ export default class RichEditor extends React.Component {
 
     var editorState = null
     if (this.props.editorState){
-      eidtorState = editorState
+      editorState = this.props.editorState
     } else if (this.props.content){
       const blocks = convertFromRaw(this.props.content);
       editorState = EditorState.createWithContent(


### PR DESCRIPTION
The variable

```
eidtorState
```

should be 

```
editorState
```

Also changed the resulting self-assignment

```
editorState = editorState
```

to

```
editorState = this.props.editorState
```

However, I'm not 100% sure that this assignment change won't break other things as I don't know much about the usage of editorState within your component.
